### PR TITLE
Replace greeting endpoint with health check endpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,14 @@
-use actix_web::{App, HttpRequest, HttpServer, Responder, web};
+use actix_web::{web, App, HttpResponse, HttpServer};
 
-async fn greet(req: HttpRequest) -> impl Responder {
-    let name = req.match_info().get("name").unwrap_or("World");
-    format!("Hello, {}!", &name)
-}
+async fn health_check() -> HttpResponse {
+        HttpResponse::Ok().finish()
+    }
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     HttpServer::new(|| {
         App::new()
-            .route("/", web::get().to(greet))
-            .route("/{name}", web::get().to(greet))
+            .route("/health_check", web::get().to(health_check))
     })
     .bind("127.0.0.1:8080")?
     .run()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,13 @@
-use actix_web::{web, App, HttpResponse, HttpServer};
+use actix_web::{App, HttpResponse, HttpServer, web};
 
 async fn health_check() -> HttpResponse {
-        HttpResponse::Ok().finish()
-    }
+    HttpResponse::Ok().finish()
+}
 
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
-    HttpServer::new(|| {
-        App::new()
-            .route("/health_check", web::get().to(health_check))
-    })
-    .bind("127.0.0.1:8080")?
-    .run()
-    .await
+    HttpServer::new(|| App::new().route("/health_check", web::get().to(health_check)))
+        .bind("127.0.0.1:8080")?
+        .run()
+        .await
 }


### PR DESCRIPTION
Removed the dynamic greeting logic and introduced a static health check endpoint. This simplifies the functionality and prepares the codebase for health monitoring needs. Also reorganized imports to remove unused items.